### PR TITLE
Rename project from plex-stats to plex-history-report

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# Dependabot configuration for plex-stats
+# Dependabot configuration for plex-history-report
 version: 2
 updates:
   # Keep Python dependencies up to date

--- a/README.md
+++ b/README.md
@@ -68,55 +68,55 @@ The tool can be run directly using the included script:
 
 ```bash
 # Basic usage for TV shows or movies
-./bin/plex-stats --tv
-./bin/plex-stats --movies
+./bin/plex-history-report --tv
+./bin/plex-history-report --movies
 
 # User-specific statistics
-./bin/plex-stats --tv --user username
-./bin/plex-stats --movies --user username
+./bin/plex-history-report --tv --user username
+./bin/plex-history-report --movies --user username
 
 # List available Plex users
-./bin/plex-stats --list-users
+./bin/plex-history-report --list-users
 ```
 
 ### Output Formats
 
 ```bash
 # Default is rich-formatted tables in the terminal
-./bin/plex-stats --tv
+./bin/plex-history-report --tv
 
 # Alternative formats
-./bin/plex-stats --tv --format json      # JSON format
-./bin/plex-stats --tv --format markdown  # Markdown format
-./bin/plex-stats --tv --format csv       # CSV format
-./bin/plex-stats --tv --format yaml      # YAML format
+./bin/plex-history-report --tv --format json      # JSON format
+./bin/plex-history-report --tv --format markdown  # Markdown format
+./bin/plex-history-report --tv --format csv       # CSV format
+./bin/plex-history-report --tv --format yaml      # YAML format
 ```
 
 ### Filtering Options
 
 ```bash
 # Show recently watched content
-./bin/plex-stats --tv --show-recent
+./bin/plex-history-report --tv --show-recent
 
 # Filter to only partially watched content
-./bin/plex-stats --tv --partially-watched-only
+./bin/plex-history-report --tv --partially-watched-only
 
 # Include unwatched content (off by default)
-./bin/plex-stats --tv --include-unwatched
+./bin/plex-history-report --tv --include-unwatched
 ```
 
 ### Sorting Options
 
 ```bash
 # Sort TV shows
-./bin/plex-stats --tv --sort-by completion_percentage
-./bin/plex-stats --tv --sort-by watched_episodes
-./bin/plex-stats --tv --sort-by last_watched
+./bin/plex-history-report --tv --sort-by completion_percentage
+./bin/plex-history-report --tv --sort-by watched_episodes
+./bin/plex-history-report --tv --sort-by last_watched
 
 # Sort movies
-./bin/plex-stats --movies --sort-by last_watched
-./bin/plex-stats --movies --sort-by watch_count
-./bin/plex-stats --movies --sort-by duration_minutes
+./bin/plex-history-report --movies --sort-by last_watched
+./bin/plex-history-report --movies --sort-by watch_count
+./bin/plex-history-report --movies --sort-by duration_minutes
 ```
 
 ### Full Command Reference
@@ -124,7 +124,7 @@ The tool can be run directly using the included script:
 Run the help command for a complete list of options:
 
 ```bash
-./bin/plex-stats --help
+./bin/plex-history-report --help
 ```
 
 ### Available Sort Options

--- a/bin/plex-history-report
+++ b/bin/plex-history-report
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Wrapper script for running plex-history-report with UV
+# This passes all arguments to the plex_history_report.cli module
+
+# Check if UV is installed
+if ! command -v uv &> /dev/null; then
+    echo "UV is not installed. Please install it first."
+    echo "Visit https://github.com/astral-sh/uv for installation instructions."
+    exit 1
+fi
+
+# Get the directory where this script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+# Get the project root directory (parent of bin)
+PROJECT_ROOT="$( dirname "$SCRIPT_DIR" )"
+
+# Change to the project directory
+cd "$PROJECT_ROOT" || exit 1
+
+# Run plex-history-report using UV, which will install dependencies on demand
+uv run -m plex_history_report.cli "$@"

--- a/bin/run-lint
+++ b/bin/run-lint
@@ -13,7 +13,7 @@ fi
 
 # Default paths to check if no arguments provided
 if [ $# -eq 0 ]; then
-    ARGS=("plex_stats" "tests")
+    ARGS=("plex_history_report" "tests")
 else
     # Use array for proper argument handling
     ARGS=("$@")

--- a/bin/test-output.sh
+++ b/bin/test-output.sh
@@ -18,25 +18,25 @@ run_test() {
 }
 
 # Basic functionality tests
-run_test "TV statistics in table format" "./bin/plex-stats --tv" "output_tv_table.txt"
-run_test "Movie statistics in table format" "./bin/plex-stats --movies" "output_movies_table.txt"
+run_test "TV statistics in table format" "./bin/plex-history-report --tv" "output_tv_table.txt"
+run_test "Movie statistics in table format" "./bin/plex-history-report --movies" "output_movies_table.txt"
 
 # Output format tests
-run_test "TV statistics in JSON format" "./bin/plex-stats --tv --format json" "output_tv_json.txt"
-run_test "TV statistics in Markdown format" "./bin/plex-stats --tv --format markdown" "output_tv_markdown.txt"
-run_test "TV statistics in CSV format" "./bin/plex-stats --tv --format csv" "output_tv_csv.txt"
-run_test "TV statistics in YAML format" "./bin/plex-stats --tv --format yaml" "output_tv_yaml.txt"
+run_test "TV statistics in JSON format" "./bin/plex-history-report --tv --format json" "output_tv_json.txt"
+run_test "TV statistics in Markdown format" "./bin/plex-history-report --tv --format markdown" "output_tv_markdown.txt"
+run_test "TV statistics in CSV format" "./bin/plex-history-report --tv --format csv" "output_tv_csv.txt"
+run_test "TV statistics in YAML format" "./bin/plex-history-report --tv --format yaml" "output_tv_yaml.txt"
 
 # Filtering tests
-run_test "Partially watched TV shows" "./bin/plex-stats --tv --partially-watched-only" "output_tv_partially_watched.txt"
-run_test "Include unwatched TV shows" "./bin/plex-stats --tv --include-unwatched" "output_tv_include_unwatched.txt"
+run_test "Partially watched TV shows" "./bin/plex-history-report --tv --partially-watched-only" "output_tv_partially_watched.txt"
+run_test "Include unwatched TV shows" "./bin/plex-history-report --tv --include-unwatched" "output_tv_include_unwatched.txt"
 
 # Debug logging test
-run_test "TV statistics with debug logging" "./bin/plex-stats --tv --debug" "output_tv_debug.txt"
+run_test "TV statistics with debug logging" "./bin/plex-history-report --tv --debug" "output_tv_debug.txt"
 
 # Sorting tests
-run_test "TV statistics sorted by completion percentage" "./bin/plex-stats --tv --sort-by completion_percentage" "output_tv_sorted_completion.txt"
-run_test "Movie statistics sorted by last watched" "./bin/plex-stats --movies --sort-by last_watched" "output_movies_sorted_last_watched.txt"
+run_test "TV statistics sorted by completion percentage" "./bin/plex-history-report --tv --sort-by completion_percentage" "output_tv_sorted_completion.txt"
+run_test "Movie statistics sorted by last watched" "./bin/plex-history-report --movies --sort-by last_watched" "output_movies_sorted_last_watched.txt"
 
 # Cleanup option
 if [[ "$1" == "clean" ]]; then

--- a/plex_history_report/__init__.py
+++ b/plex_history_report/__init__.py
@@ -1,0 +1,6 @@
+"""Plex History Report.
+
+A tool to analyze and visualize Plex TV show and movie watching habits.
+"""
+
+__version__ = "0.1.0"

--- a/plex_history_report/cli.py
+++ b/plex_history_report/cli.py
@@ -1,6 +1,6 @@
-"""Command-line interface for Plex Stats.
+"""Command-line interface for Plex History Reports.
 
-This module provides the command-line interface for the plex-stats tool.
+This module provides the command-line interface for the plex-history-report tool.
 """
 
 import argparse
@@ -11,8 +11,13 @@ from pathlib import Path
 from rich.console import Console
 from rich.logging import RichHandler
 
-from plex_stats.config import DEFAULT_CONFIG_PATH, ConfigError, create_default_config, load_config
-from plex_stats.formatters import (
+from plex_history_report.config import (
+    DEFAULT_CONFIG_PATH,
+    ConfigError,
+    create_default_config,
+    load_config,
+)
+from plex_history_report.formatters import (
     CompactFormatter,
     CsvFormatter,
     JsonFormatter,
@@ -20,7 +25,7 @@ from plex_stats.formatters import (
     RichFormatter,
     YamlFormatter,
 )
-from plex_stats.plex_client import PlexClient, PlexClientError
+from plex_history_report.plex_client import PlexClient, PlexClientError
 
 # Configure logging
 logging.basicConfig(
@@ -30,7 +35,7 @@ logging.basicConfig(
     handlers=[RichHandler(rich_tracebacks=True)]
 )
 
-logger = logging.getLogger("plex_stats")
+logger = logging.getLogger("plex_history_report")
 
 
 # Define available sort options for different media types
@@ -135,7 +140,7 @@ def configure_parser() -> argparse.ArgumentParser:
 
 
 def run(args: argparse.Namespace) -> int:
-    """Run the plex-stats tool.
+    """Run the plex-history-report tool.
 
     Args:
         args: Command-line arguments.
@@ -147,7 +152,7 @@ def run(args: argparse.Namespace) -> int:
 
     # Configure logging level
     if args.debug:
-        logging.getLogger("plex_stats").setLevel(logging.DEBUG)
+        logging.getLogger("plex_history_report").setLevel(logging.DEBUG)
         logger.debug("Debug logging enabled")
 
     # Create default config if requested
@@ -318,7 +323,7 @@ def run(args: argparse.Namespace) -> int:
 
 
 def main() -> None:
-    """Main entry point for the plex-stats CLI."""
+    """Main entry point for the plex-history-report CLI."""
     parser = configure_parser()
     args = parser.parse_args()
 

--- a/plex_history_report/config.py
+++ b/plex_history_report/config.py
@@ -1,4 +1,4 @@
-"""Configuration handler for Plex Stats.
+"""Configuration handler for Plex History Report.
 
 This module handles loading and validating configuration from a YAML file.
 """

--- a/plex_history_report/formatters.py
+++ b/plex_history_report/formatters.py
@@ -1,4 +1,4 @@
-"""Formatters for displaying Plex statistics.
+"""Formatters for displaying Plex History Report statistics.
 
 This module provides various formatters for displaying Plex statistics
 in different formats like text tables, JSON, etc.

--- a/plex_history_report/plex_client.py
+++ b/plex_history_report/plex_client.py
@@ -1,4 +1,4 @@
-"""Plex client module for retrieving statistics."""
+"""Plex client module for retrieving Plex History Report statistics."""
 
 import logging
 from datetime import datetime

--- a/plex_stats/__init__.py
+++ b/plex_stats/__init__.py
@@ -1,6 +1,0 @@
-"""Plex Statistics Tracker.
-
-A tool to analyze and visualize Plex TV show watching habits.
-"""
-
-__version__ = "0.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=42.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "plex-stats"
+name = "plex-history-report"
 version = "0.1.0"
 description = "Tool to track Plex TV show watch statistics"
 readme = "README.md"
@@ -27,10 +27,10 @@ dev = [
 ]
 
 [project.scripts]
-plex-stats = "plex_stats.cli:main"
+plex-history-report = "plex_history_report.cli:main"
 
 [tool.setuptools]
-packages = ["plex_stats"]
+packages = ["plex_history_report"]
 
 [tool.ruff]
 target-version = "py38"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,7 @@ import unittest
 from contextlib import suppress
 from unittest.mock import MagicMock, patch
 
-from plex_stats.cli import configure_parser, run
+from plex_history_report.cli import configure_parser, run
 
 
 class TestCLIParser(unittest.TestCase):
@@ -44,9 +44,9 @@ class TestCLIParser(unittest.TestCase):
     def test_detailed_to_show_recent_mapping(self):
         """Test that --detailed maps to --show-recent."""
         # Create a mock object for run function's dependencies
-        with patch('plex_stats.cli.load_config'), \
-             patch('plex_stats.cli.PlexClient'), \
-             patch('plex_stats.cli.RichFormatter'):
+        with patch('plex_history_report.cli.load_config'), \
+             patch('plex_history_report.cli.PlexClient'), \
+             patch('plex_history_report.cli.RichFormatter'):
 
             # Parse args with --detailed
             args = self.parser.parse_args(['--tv', '--detailed'])
@@ -57,8 +57,8 @@ class TestCLIParser(unittest.TestCase):
             mock_console = MagicMock()
 
             # Run with args containing --detailed
-            with patch('plex_stats.cli.Console', return_value=mock_console), \
-                 patch('plex_stats.cli.logger'), \
+            with patch('plex_history_report.cli.Console', return_value=mock_console), \
+                 patch('plex_history_report.cli.logger'), \
                  suppress(Exception):
                 run(args)
 
@@ -80,11 +80,11 @@ class TestCLIParser(unittest.TestCase):
         mock_client = MagicMock()
         mock_client.get_all_movie_statistics.return_value = mock_movies
 
-        with patch('plex_stats.cli.load_config', return_value={'plex': {'base_url': 'test', 'token': 'test'}}), \
-             patch('plex_stats.cli.PlexClient', return_value=mock_client), \
-             patch('plex_stats.cli.RichFormatter'), \
-             patch('plex_stats.cli.Console', return_value=MagicMock()), \
-             patch('plex_stats.cli.logger'):
+        with patch('plex_history_report.cli.load_config', return_value={'plex': {'base_url': 'test', 'token': 'test'}}), \
+             patch('plex_history_report.cli.PlexClient', return_value=mock_client), \
+             patch('plex_history_report.cli.RichFormatter'), \
+             patch('plex_history_report.cli.Console', return_value=MagicMock()), \
+             patch('plex_history_report.cli.logger'):
 
             # Parse args with --partially-watched-only
             args = self.parser.parse_args(['--movies', '--partially-watched-only'])
@@ -121,11 +121,11 @@ class TestCLIParser(unittest.TestCase):
         mock_client = MagicMock()
         mock_client.get_all_show_statistics.return_value = mock_shows
 
-        with patch('plex_stats.cli.load_config', return_value={'plex': {'base_url': 'test', 'token': 'test'}}), \
-             patch('plex_stats.cli.PlexClient', return_value=mock_client), \
-             patch('plex_stats.cli.RichFormatter'), \
-             patch('plex_stats.cli.Console', return_value=MagicMock()), \
-             patch('plex_stats.cli.logger'):
+        with patch('plex_history_report.cli.load_config', return_value={'plex': {'base_url': 'test', 'token': 'test'}}), \
+             patch('plex_history_report.cli.PlexClient', return_value=mock_client), \
+             patch('plex_history_report.cli.RichFormatter'), \
+             patch('plex_history_report.cli.Console', return_value=MagicMock()), \
+             patch('plex_history_report.cli.logger'):
 
             # Parse args with --partially-watched-only
             args = self.parser.parse_args(['--tv', '--partially-watched-only'])
@@ -149,15 +149,15 @@ class TestCLIParser(unittest.TestCase):
 
     def test_debug_logging(self):
         """Test that debug logging is enabled when --debug flag is used."""
-        # Create a mock for plex_stats.cli.logger directly
+        # Create a mock for plex_history_report.cli.logger directly
         mock_logger = MagicMock()
 
         # Now patch dependencies including the logger in cli.py
-        with patch('plex_stats.cli.logger', mock_logger), \
-             patch('plex_stats.cli.load_config'), \
-             patch('plex_stats.cli.PlexClient'), \
-             patch('plex_stats.cli.RichFormatter'), \
-             patch('plex_stats.cli.Console', return_value=MagicMock()):
+        with patch('plex_history_report.cli.logger', mock_logger), \
+             patch('plex_history_report.cli.load_config'), \
+             patch('plex_history_report.cli.PlexClient'), \
+             patch('plex_history_report.cli.RichFormatter'), \
+             patch('plex_history_report.cli.Console', return_value=MagicMock()):
 
             # Parse args with --debug
             args = self.parser.parse_args(['--tv', '--debug'])
@@ -186,11 +186,11 @@ class TestCLIParser(unittest.TestCase):
         mock_client = MagicMock()
         mock_client.get_all_show_statistics.return_value = mock_shows
 
-        with patch('plex_stats.cli.load_config', return_value={'plex': {'base_url': 'test', 'token': 'test'}}), \
-             patch('plex_stats.cli.PlexClient', return_value=mock_client), \
-             patch('plex_stats.cli.RichFormatter'), \
-             patch('plex_stats.cli.Console', return_value=MagicMock()), \
-             patch('plex_stats.cli.logger'):
+        with patch('plex_history_report.cli.load_config', return_value={'plex': {'base_url': 'test', 'token': 'test'}}), \
+             patch('plex_history_report.cli.PlexClient', return_value=mock_client), \
+             patch('plex_history_report.cli.RichFormatter'), \
+             patch('plex_history_report.cli.Console', return_value=MagicMock()), \
+             patch('plex_history_report.cli.logger'):
 
             # Case 1: Normal filtering (default)
             args = self.parser.parse_args(['--tv'])

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 
 import yaml
 
-from plex_stats.formatters import (
+from plex_history_report.formatters import (
     CsvFormatter,
     JsonFormatter,
     MarkdownFormatter,

--- a/uv.lock
+++ b/uv.lock
@@ -356,7 +356,7 @@ wheels = [
 ]
 
 [[package]]
-name = "plex-stats"
+name = "plex-history-report"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
This PR implements a comprehensive project rename from 'plex-stats' to 'plex-history-report' to better reflect the purpose of the tool.

## Changes
- Renamed package directory from plex_stats to plex_history_report
- Updated all import statements throughout the codebase
- Updated package references in pyproject.toml 
- Updated binary name and references
- Updated documentation and docstrings
- Updated references in test files and output samples
- Updated script references in CI workflows

All tests and linting checks are passing with the new package structure.