### PR TITLE
Migrate from TODO.md to GitHub Issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,5 @@ htmlcov/
 
 # Project-specific
 config.yaml
-TODO.md
 test_output/
 .bin/


### PR DESCRIPTION
## Changes

This PR completes the migration from using TODO.md to GitHub Issues for task tracking:

- Remove TODO.md from .gitignore since we won't be using it anymore
- Created GitHub Issue #11 for "Enable Dependabot for GitHub Actions" which was previously tracked in TODO.md
- Other TODO items were evaluated and determined not to be needed at this time

## Benefits

- Better task tracking through GitHub Issues
- Improved visibility into project status and priorities
- Integration with GitHub's project management features
- Cleaner repository structure without the need for a separate TODO file

This PR is part of improving our project management workflow by standardizing on GitHub Issues for all task tracking.