### PR TITLE
Fix Dependabot configuration (Issues #8 & #11)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,26 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    # Allow execution of external code required by some Python packages
+    insecure-external-code-execution: allow
     # Use uv as package manager
     registries:
       - uv-python
     # Group dependencies together in a single PR
     groups:
       dependencies:
+        patterns:
+          - "*"
+
+  # Keep GitHub Actions up to date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    # Group actions updates in a single PR
+    groups:
+      github-actions:
         patterns:
           - "*"
 


### PR DESCRIPTION
## Changes

This PR addresses two Dependabot-related issues:

### Issue #8: Fix Python Dependabot Configuration
- Added `insecure-external-code-execution: allow` setting to the Python ecosystem configuration
- This resolves the error "Dependabot refused to execute external code" which was preventing Python dependency updates
- Groups all Python dependency updates into a single PR for easier management

### Issue #11: Enable Dependabot for GitHub Actions
- Added GitHub Actions ecosystem to Dependabot configuration
- Set weekly updates for GitHub Actions
- Limited to 5 open PRs at a time 
- Groups all GitHub Actions updates into a single PR

### Benefits
- Fixes broken Dependabot functionality for Python dependencies
- Improves security by automatically keeping GitHub Actions up-to-date
- Reduces PR noise by grouping updates
- Follows best practices for both Python and GitHub Actions ecosystems

### Testing
All checks pass successfully with these changes, including:
- EditorConfig lint
- Markdown lint
- ShellCheck
- Python linting
- Python tests

Closes #8
Closes #11