### PR TITLE
Fix issue #9: Properly implement compact output format

### DIFF
--- a/plex_history_report/cli.py
+++ b/plex_history_report/cli.py
@@ -295,6 +295,21 @@ def run(args: argparse.Namespace) -> int:
                 else:
                     recently_watched = client.get_recently_watched_movies(username=username)
                     formatter.format_recently_watched(recently_watched, media_type="movie")
+        elif args.format == "compact":
+            # Special handling for compact format
+            if args.tv:
+                output = formatter.format_show_statistics(stats)
+            else:
+                output = formatter.format_movie_statistics(stats)
+            console.print(output)
+
+            if args.show_recent:
+                if args.tv:
+                    recently_watched = client.get_recently_watched_shows(username=username)
+                else:
+                    recently_watched = client.get_recently_watched_movies(username=username)
+                recently_output = formatter.format_recently_watched(recently_watched, media_type=media_type)
+                console.print(recently_output)
         else:
             # Non-table output (json, markdown, csv, yaml)
             if args.tv:

--- a/plex_history_report/formatters.py
+++ b/plex_history_report/formatters.py
@@ -904,7 +904,7 @@ class CompactFormatter(BaseFormatter):
             return "NoShows"
 
         # Use short but descriptive column headers
-        lines = ["Title|Watched|Total|WatchTime"]
+        lines = ["Title|WatchedEps|TotalEps|WatchTime"]
 
         # Add rows for each show with minimal separators
         for show in stats:
@@ -918,18 +918,6 @@ class CompactFormatter(BaseFormatter):
 
             # Create compact row
             lines.append(f"{title}|{show['watched_episodes']}|{show['total_episodes']}|{watch_time}")
-
-        # Add compact summary (S: for summary)
-        total_shows = len(stats)
-        watched_shows = sum(1 for show in stats if show['watched_episodes'] > 0)
-        total_episodes = sum(show['total_episodes'] for show in stats)
-        watched_episodes = sum(show['watched_episodes'] for show in stats)
-        total_watch_time = sum(show['total_watch_time_minutes'] for show in stats)
-
-        hours = int(total_watch_time // 60)
-        minutes = int(total_watch_time % 60)
-
-        lines.append(f"Summary: TotalShows={total_shows} WatchedShows={watched_shows} Episodes={watched_episodes}/{total_episodes} TotalWatchTime={hours}h{minutes}m")
 
         return "\n".join(lines)
 
@@ -972,20 +960,6 @@ class CompactFormatter(BaseFormatter):
 
             # Create compact row
             lines.append(f"{title}|{movie['watch_count']}|{formatted_date}|{duration}|{rating}")
-
-        # Add compact summary
-        total_movies = len(stats)
-        watched_movies = sum(1 for movie in stats if movie['watched'])
-        watch_count = sum(movie['watch_count'] for movie in stats)
-        total_duration = sum(movie['duration_minutes'] for movie in stats)
-        watched_duration = sum(movie['duration_minutes'] * movie['watch_count'] for movie in stats if movie['watched'])
-
-        tot_h = int(total_duration // 60)
-        tot_m = int(total_duration % 60)
-        wat_h = int(watched_duration // 60)
-        wat_m = int(watched_duration % 60)
-
-        lines.append(f"Summary: TotalMovies={total_movies} WatchedMovies={watched_movies} TotalWatches={watch_count} TotalDuration={tot_h}h{tot_m}m WatchedDuration={wat_h}h{wat_m}m")
 
         return "\n".join(lines)
 


### PR DESCRIPTION
This PR fixes issue #9 where the compact output format wasn't fully implemented.

## Changes
- Added special handling for compact format in `cli.py` to properly handle the output and recently watched content
- Made TV show column headers clearer (`WatchedEps`/`TotalEps` instead of `Watched`/`Total`) 
- Removed summary information from compact output as requested

All tests are passing, confirming that these changes work as expected.

Fixes #9