### PR TITLE
ci: optimize linting workflows and add formatters (fixes #31)

### DIFF
--- a/.github/workflows/run-black.yml
+++ b/.github/workflows/run-black.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run Black formatter
         run: |
           ./scripts/run-black
-          
+
       - name: Check for formatting changes
         run: |
           if ! git --no-pager diff --exit-code; then

--- a/.github/workflows/run-black.yml
+++ b/.github/workflows/run-black.yml
@@ -1,4 +1,4 @@
-name: Python Linting
+name: Black Python Formatting
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  lint:
+  black:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,6 +27,13 @@ jobs:
         run: |
           uv venv
 
-      - name: Run linter
+      - name: Run Black formatter
         run: |
-          ./scripts/run-lint
+          ./scripts/run-black
+          
+      - name: Check for formatting changes
+        run: |
+          if ! git --no-pager diff --exit-code; then
+            echo "::error::Black found formatting issues. Please run ./scripts/run-black locally and commit the changes."
+            exit 1
+          fi

--- a/.github/workflows/run-markdown-lint.yml
+++ b/.github/workflows/run-markdown-lint.yml
@@ -9,16 +9,13 @@ on:
 jobs:
   markdown-lint:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.8", "3.x"]
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.x"
 
       - name: Install uv
         shell: bash

--- a/.github/workflows/run-prettier.yml
+++ b/.github/workflows/run-prettier.yml
@@ -1,0 +1,31 @@
+name: Prettier Formatting
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  prettier:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Prettier
+        run: ./scripts/run-prettier
+
+      - name: Check for formatting changes
+        run: |
+          if ! git --no-pager diff --exit-code; then
+            echo "::error::Prettier found formatting issues. Please run ./scripts/run-prettier locally and commit the changes."
+            exit 1
+          fi

--- a/.github/workflows/run-prettier.yml
+++ b/.github/workflows/run-prettier.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: "20"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/run-ruff-fix.yml
+++ b/.github/workflows/run-ruff-fix.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run Ruff auto-fix
         run: |
           ./scripts/run-ruff-fix
-          
+
       - name: Check for auto-fix changes
         run: |
           if ! git --no-pager diff --exit-code; then

--- a/.github/workflows/run-ruff-fix.yml
+++ b/.github/workflows/run-ruff-fix.yml
@@ -1,4 +1,4 @@
-name: Python Linting
+name: Ruff Python Auto-fixes
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  lint:
+  ruff-fix:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,6 +27,13 @@ jobs:
         run: |
           uv venv
 
-      - name: Run linter
+      - name: Run Ruff auto-fix
         run: |
-          ./scripts/run-lint
+          ./scripts/run-ruff-fix
+          
+      - name: Check for auto-fix changes
+        run: |
+          if ! git --no-pager diff --exit-code; then
+            echo "::error::Ruff found issues that need fixing. Please run ./scripts/run-ruff-fix locally and commit the changes."
+            exit 1
+          fi

--- a/.github/workflows/run-shellcheck.yml
+++ b/.github/workflows/run-shellcheck.yml
@@ -9,16 +9,13 @@ on:
 jobs:
   shellcheck:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.8", "3.x"]
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.x"
 
       - name: Install uv
         shell: bash

--- a/scripts/run-editorconfig-lint
+++ b/scripts/run-editorconfig-lint
@@ -69,9 +69,13 @@ if [ $# -eq 0 ]; then
     # Get all tracked files from git
     ARGS=()
     while IFS= read -r file; do
-        # Skip Markdown files (handled by Prettier/markdown-lint)
-        if [[ "$file" != *.md ]]; then
-            ARGS+=("$file")
+        # Skip .bin directory and Markdown files
+        if [[ "$file" != .bin/* && "$file" != *.md ]]; then
+            # Check if the file is a text file by looking for null bytes
+            # Binary files almost always contain null bytes, text files almost never do
+            if ! grep -q -U $'\x00' "$file" 2>/dev/null; then
+                ARGS+=("$file")
+            fi
         fi
     done < <(git --no-pager ls-files)
 else


### PR DESCRIPTION
This PR addresses the linting issues mentioned in #31:

## Changes

### 1. Fixed Multiple Python Version Issue
- Updated all linting workflows to use a single Python version (3.x) instead of running on multiple versions:
  - Modified `run-lint.yml`
  - Modified `run-shellcheck.yml`
  - Modified `run-markdown-lint.yml`

### 2. Added Missing Formatter Workflows
- Added GitHub Action workflows for all formatters:
  - New `run-prettier.yml` workflow for text formatting
  - New `run-black.yml` workflow for Python formatting
  - New `run-ruff-fix.yml` workflow for Python auto-fixes

### 3. Smart Checking for Formatting Issues
- Used a more elegant approach for checking formatting without duplicate scripts:
  - Run formatters normally first
  - Use `git diff` to detect if any files were changed
  - Fail the CI job if formatting changes are detected, with helpful error messages

This ensures CI will detect when files need formatting, but without creating separate check-only scripts.

Fixes #31