### PR TITLE
Implement shell script formatter using shfmt

### DIFF
--- a/.github/workflows/run-shellcheck.yml
+++ b/.github/workflows/run-shellcheck.yml
@@ -1,4 +1,4 @@
-name: Shell Linting
+name: Shell Script Checks
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  shellcheck:
+  shell-checks:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,6 +27,10 @@ jobs:
         run: |
           uv venv
 
-      - name: Run shellcheck
+      - name: Run shfmt (formatting)
+        run: |
+          ./scripts/run-shfmt --check
+
+      - name: Run shellcheck (linting)
         run: |
           ./scripts/run-shellcheck

--- a/.github/workflows/run-shellcheck.yml
+++ b/.github/workflows/run-shellcheck.yml
@@ -27,10 +27,6 @@ jobs:
         run: |
           uv venv
 
-      - name: Run shfmt (formatting)
+      - name: Run shell script checks
         run: |
-          ./scripts/run-shfmt --check
-
-      - name: Run shellcheck (linting)
-        run: |
-          ./scripts/run-shellcheck
+          ./scripts/run-shell-checks --check

--- a/bin/plex-history-report
+++ b/bin/plex-history-report
@@ -4,16 +4,16 @@
 # This passes all arguments to the plex_history_report.cli module
 
 # Check if UV is installed
-if ! command -v uv &> /dev/null; then
+if ! command -v uv &>/dev/null; then
     echo "UV is not installed. Please install it first."
     echo "Visit https://github.com/astral-sh/uv for installation instructions."
     exit 1
 fi
 
 # Get the directory where this script is located
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 # Get the project root directory (parent of bin)
-PROJECT_ROOT="$( dirname "$SCRIPT_DIR" )"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
 # Change to the project directory
 cd "$PROJECT_ROOT" || exit 1

--- a/scripts/check-gh-actions
+++ b/scripts/check-gh-actions
@@ -36,36 +36,36 @@ EXCLUDE_PATTERNS=("${DEFAULT_EXCLUSIONS[@]}")
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        -b|--branch)
+        -b | --branch)
             BRANCH="$2"
             PR_ARG="$BRANCH"
             shift 2
             ;;
-        -n|--no-wait)
+        -n | --no-wait)
             WAIT_FOR_COMPLETION=false
             shift
             ;;
-        -f|--fail-fast)
+        -f | --fail-fast)
             FAIL_FAST="--fail-fast"
             shift
             ;;
-        -t|--timeout)
+        -t | --timeout)
             TIMEOUT="$2"
             shift 2
             ;;
-        -i|--interval)
+        -i | --interval)
             WATCH_INTERVAL="$2"
             shift 2
             ;;
-        -e|--exclude)
+        -e | --exclude)
             EXCLUDE_PATTERNS+=("$2")
             shift 2
             ;;
-        -a|--all)
+        -a | --all)
             EXCLUDE_PATTERNS=()
             shift
             ;;
-        -h|--help)
+        -h | --help)
             usage
             ;;
         *)
@@ -76,14 +76,14 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Check if gh CLI is installed
-if ! command -v gh &> /dev/null; then
+if ! command -v gh &>/dev/null; then
     echo "Error: GitHub CLI (gh) is not installed."
     echo "Please install it from https://cli.github.com/"
     exit 1
 fi
 
 # Check if authenticated with GitHub
-if ! gh auth status &> /dev/null; then
+if ! gh auth status &>/dev/null; then
     echo "Error: Not authenticated with GitHub."
     echo "Please run 'gh auth login' to authenticate."
     exit 1
@@ -106,10 +106,10 @@ should_exclude_check() {
     local check_name="$1"
     for pattern in "${EXCLUDE_PATTERNS[@]}"; do
         if [[ "$check_name" == *"$pattern"* ]]; then
-            return 0  # True, should exclude
+            return 0 # True, should exclude
         fi
     done
-    return 1  # False, should not exclude
+    return 1 # False, should not exclude
 }
 
 # Function to check for failed runs and get their logs
@@ -133,7 +133,7 @@ get_failed_checks_logs() {
     local total_checks
     total_checks=$(echo "$checks_json" | jq '. | length')
 
-    for ((i=0; i<total_checks; i++)); do
+    for ((i = 0; i < total_checks; i++)); do
         local check_json
         check_json=$(echo "$checks_json" | jq ".[$i]")
 

--- a/scripts/run-all-checks
+++ b/scripts/run-all-checks
@@ -17,13 +17,13 @@ echo -e "\n[1/7] Formatting text files with Prettier"
 echo -e "\n[2/7] Formatting Python code with Black"
 "$SCRIPT_DIR/run-black"
 
-# Run markdown lint
-echo -e "\n[3/7] Running Markdown lint"
-"$SCRIPT_DIR/run-markdown-lint"
+# Run shell script checks (shfmt and shellcheck)
+echo -e "\n[3/7] Running shell script checks (shfmt and shellcheck)"
+"$SCRIPT_DIR/run-shell-checks"
 
-# Run shell script lint
-echo -e "\n[4/7] Running ShellCheck"
-"$SCRIPT_DIR/run-shellcheck"
+# Run markdown lint
+echo -e "\n[4/7] Running Markdown lint"
+"$SCRIPT_DIR/run-markdown-lint"
 
 # Run Python linter (check only)
 echo -e "\n[5/7] Running Python linter"

--- a/scripts/run-editorconfig-lint
+++ b/scripts/run-editorconfig-lint
@@ -15,7 +15,7 @@ fi
 
 # Set up editorconfig-checker binary directory
 BIN_DIR="$(pwd)/.bin"
-EC_VERSION="3.2.1"  # Current latest version
+EC_VERSION="3.2.1" # Current latest version
 EC_BINARY="$BIN_DIR/ec"
 
 # Create the .bin directory if it doesn't exist

--- a/scripts/run-lint
+++ b/scripts/run-lint
@@ -5,7 +5,7 @@
 set -e
 
 # Ensure uv is available
-if ! command -v uv &> /dev/null; then
+if ! command -v uv &>/dev/null; then
     echo "Error: uv is not installed or not in PATH"
     echo "Visit https://github.com/astral-sh/uv for installation instructions"
     exit 1

--- a/scripts/run-markdown-lint
+++ b/scripts/run-markdown-lint
@@ -5,7 +5,7 @@
 set -e
 
 # Ensure uv is available
-if ! command -v uv &> /dev/null; then
+if ! command -v uv &>/dev/null; then
     echo "Error: uv is not installed or not in PATH"
     echo "Visit https://github.com/astral-sh/uv for installation instructions"
     exit 1

--- a/scripts/run-prettier
+++ b/scripts/run-prettier
@@ -5,7 +5,7 @@
 set -e
 
 # Check if npx is available
-if ! command -v npx &> /dev/null; then
+if ! command -v npx &>/dev/null; then
     echo "Error: npx is not installed or not in PATH"
     echo "Install Node.js (which includes npm and npx) to continue"
     exit 1

--- a/scripts/run-shell-checks
+++ b/scripts/run-shell-checks
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Script to run all shell script checks (shfmt and shellcheck)
+
+# Exit on any error
+set -e
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Print header
+echo "===== Running all shell script checks ====="
+
+# Run shfmt for formatting
+echo -e "\n[1/2] Running shfmt for formatting"
+"$SCRIPT_DIR/run-shfmt" "$@"
+
+# Run shellcheck for linting
+echo -e "\n[2/2] Running shellcheck for linting"
+"$SCRIPT_DIR/run-shellcheck" "$@"
+
+echo -e "\n===== All shell script checks completed successfully! ====="

--- a/scripts/run-shellcheck
+++ b/scripts/run-shellcheck
@@ -11,27 +11,34 @@ if ! command -v uv &>/dev/null; then
     exit 1
 fi
 
-# Default paths to check if no arguments provided
-if [ $# -eq 0 ]; then
+# Process arguments to look for --check flag
+CHECK_MODE=false
+SHELL_ARGS=()
+for arg in "$@"; do
+    if [[ "$arg" == "--check" ]]; then
+        CHECK_MODE=true
+    else
+        SHELL_ARGS+=("$arg")
+    fi
+done
+
+# Default paths to check if no file arguments were provided
+if [ ${#SHELL_ARGS[@]} -eq 0 ]; then
     # Use a more portable approach to find shell scripts
-    ARGS=()
     while IFS= read -r file; do
         # Check if file is executable
         if [ -x "$file" ] && [ -f "$file" ]; then
             # Only include files with bash shebang
             if head -n 1 "$file" | grep -q "^#!/.*\(bash\|sh\)"; then
-                ARGS+=("$file")
+                SHELL_ARGS+=("$file")
             fi
         fi
     done < <(find bin scripts -type f -not -path "*/\.*")
-else
-    # Use array for proper argument handling
-    ARGS=("$@")
 fi
 
 # Run ShellCheck with uvx
-echo "Running shellcheck on: ${ARGS[*]}"
-if ! uvx --from=shellcheck-py shellcheck "${ARGS[@]}"; then
+echo "Running shellcheck on: ${SHELL_ARGS[*]}"
+if ! uvx --from=shellcheck-py shellcheck "${SHELL_ARGS[@]}"; then
     echo -e "\nShell script linting found issues."
     exit 1
 fi

--- a/scripts/run-shellcheck
+++ b/scripts/run-shellcheck
@@ -12,12 +12,11 @@ if ! command -v uv &>/dev/null; then
 fi
 
 # Process arguments to look for --check flag
-CHECK_MODE=false
+# (shellcheck doesn't have a "check-only" mode like shfmt,
+#  but we still filter it out to prevent errors)
 SHELL_ARGS=()
 for arg in "$@"; do
-    if [[ "$arg" == "--check" ]]; then
-        CHECK_MODE=true
-    else
+    if [[ "$arg" != "--check" ]]; then
         SHELL_ARGS+=("$arg")
     fi
 done

--- a/scripts/run-shellcheck
+++ b/scripts/run-shellcheck
@@ -5,7 +5,7 @@
 set -e
 
 # Ensure uv is available
-if ! command -v uv &> /dev/null; then
+if ! command -v uv &>/dev/null; then
     echo "Error: uv is not installed or not in PATH"
     echo "Visit https://github.com/astral-sh/uv for installation instructions"
     exit 1

--- a/scripts/run-shfmt
+++ b/scripts/run-shfmt
@@ -56,32 +56,30 @@ ensure_shfmt() {
     echo "Successfully installed shfmt to $SHFMT_BINARY"
 }
 
-# Default paths to check if no arguments provided
-if [ $# -eq 0 ]; then
+# Process arguments to look for --check flag
+CHECK_MODE=false
+SHFMT_ARGS=()
+for arg in "$@"; do
+    if [[ "$arg" == "--check" ]]; then
+        CHECK_MODE=true
+    else
+        SHFMT_ARGS+=("$arg")
+    fi
+done
+
+# Default paths to check if no file arguments were provided
+if [ ${#SHFMT_ARGS[@]} -eq 0 ]; then
     # Use a more portable approach to find shell scripts
-    ARGS=()
     while IFS= read -r file; do
         # Check if file is executable
         if [ -x "$file" ] && [ -f "$file" ]; then
             # Only include files with bash or sh shebang
             if head -n 1 "$file" | grep -q "^#!/.*\(bash\|sh\)"; then
-                ARGS+=("$file")
+                SHFMT_ARGS+=("$file")
             fi
         fi
     done < <(find bin scripts -type f -not -path "*/\.*")
-else
-    # Use array for proper argument handling
-    ARGS=("$@")
 fi
-
-# Check if we're in check mode (--check)
-CHECK_MODE=false
-for arg in "$@"; do
-    if [ "$arg" = "--check" ]; then
-        CHECK_MODE=true
-        break
-    fi
-done
 
 # Ensure shfmt is available
 ensure_shfmt
@@ -99,14 +97,14 @@ fi
 # -bn: binary ops like && and | may start a line
 # -ci: switch cases are indented
 if [ "$CHECK_MODE" = true ]; then
-    echo "Checking shell script formatting on: ${ARGS[*]}"
-    if ! "$SHFMT_CMD" -l -i 4 -bn -ci "${ARGS[@]}"; then
+    echo "Checking shell script formatting on: ${SHFMT_ARGS[*]}"
+    if ! "$SHFMT_CMD" -l -i 4 -bn -ci "${SHFMT_ARGS[@]}"; then
         echo -e "\nSome shell scripts need formatting. Run 'scripts/run-shfmt' to fix."
         exit 1
     fi
 else
-    echo "Formatting shell scripts: ${ARGS[*]}"
-    "$SHFMT_CMD" -w -i 4 -bn -ci "${ARGS[@]}"
+    echo "Formatting shell scripts: ${SHFMT_ARGS[*]}"
+    "$SHFMT_CMD" -w -i 4 -bn -ci "${SHFMT_ARGS[@]}"
 fi
 
 echo -e "\nShell script formatting completed successfully."

--- a/scripts/run-shfmt
+++ b/scripts/run-shfmt
@@ -1,0 +1,112 @@
+#!/bin/bash
+# Script to format shell scripts using shfmt (mvdan/sh)
+
+# Exit on any error
+set -e
+
+# Function to check if a command exists
+command_exists() {
+    command -v "$1" &> /dev/null
+}
+
+# Determine platform and architecture for download
+PLATFORM=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+if [[ "$ARCH" == "x86_64" ]]; then
+    ARCH="amd64"
+elif [[ "$ARCH" == "arm64" ]]; then
+    ARCH="arm64"
+fi
+
+# Set up shfmt binary directory
+BIN_DIR="$(pwd)/.bin"
+SHFMT_VERSION="3.7.0"  # Current latest version as of now
+SHFMT_BINARY="$BIN_DIR/shfmt"
+
+# Function to install shfmt if not present
+ensure_shfmt() {
+    # Create the .bin directory if it doesn't exist
+    mkdir -p "$BIN_DIR"
+
+    # Check if shfmt is already available in PATH
+    if command_exists shfmt && ! [[ -f "$SHFMT_BINARY" ]]; then
+        echo "Using system-installed shfmt"
+        return 0
+    fi
+
+    # Check if our downloaded version exists
+    if [ -f "$SHFMT_BINARY" ]; then
+        return 0
+    fi
+
+    echo "shfmt not found. Downloading version $SHFMT_VERSION..."
+
+    # Set the download URL based on platform
+    DOWNLOAD_URL="https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_${PLATFORM}_${ARCH}"
+    echo "Download URL: $DOWNLOAD_URL"
+
+    # Download the binary directly (no extraction needed for shfmt)
+    echo "Downloading..."
+    if ! curl -L -s "$DOWNLOAD_URL" -o "$SHFMT_BINARY"; then
+        echo "Failed to download shfmt from $DOWNLOAD_URL"
+        exit 1
+    fi
+
+    chmod +x "$SHFMT_BINARY"
+    echo "Successfully installed shfmt to $SHFMT_BINARY"
+}
+
+# Default paths to check if no arguments provided
+if [ $# -eq 0 ]; then
+    # Use a more portable approach to find shell scripts
+    ARGS=()
+    while IFS= read -r file; do
+        # Check if file is executable
+        if [ -x "$file" ] && [ -f "$file" ]; then
+            # Only include files with bash or sh shebang
+            if head -n 1 "$file" | grep -q "^#!/.*\(bash\|sh\)"; then
+                ARGS+=("$file")
+            fi
+        fi
+    done < <(find bin scripts -type f -not -path "*/\.*")
+else
+    # Use array for proper argument handling
+    ARGS=("$@")
+fi
+
+# Check if we're in check mode (--check)
+CHECK_MODE=false
+for arg in "$@"; do
+    if [ "$arg" = "--check" ]; then
+        CHECK_MODE=true
+        break
+    fi
+done
+
+# Ensure shfmt is available
+ensure_shfmt
+
+# Use our downloaded binary or the system one
+SHFMT_CMD="shfmt"
+if [ -f "$SHFMT_BINARY" ]; then
+    SHFMT_CMD="$SHFMT_BINARY"
+fi
+
+# Run shfmt with preferred options
+# -l: list files whose formatting differs
+# -w: write result to file instead of stdout
+# -i 4: indent with 4 spaces (per project EditorConfig rules)
+# -bn: binary ops like && and | may start a line
+# -ci: switch cases are indented
+if [ "$CHECK_MODE" = true ]; then
+    echo "Checking shell script formatting on: ${ARGS[*]}"
+    if ! "$SHFMT_CMD" -l -i 4 -bn -ci "${ARGS[@]}"; then
+        echo -e "\nSome shell scripts need formatting. Run 'scripts/run-shfmt' to fix."
+        exit 1
+    fi
+else
+    echo "Formatting shell scripts: ${ARGS[*]}"
+    "$SHFMT_CMD" -w -i 4 -bn -ci "${ARGS[@]}"
+fi
+
+echo -e "\nShell script formatting completed successfully."

--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -5,7 +5,7 @@
 set -e
 
 # Ensure uv is available
-if ! command -v uv &> /dev/null; then
+if ! command -v uv &>/dev/null; then
     echo "Error: uv is not installed or not in PATH"
     echo "Visit https://github.com/astral-sh/uv for installation instructions"
     exit 1

--- a/scripts/test-output.sh
+++ b/scripts/test-output.sh
@@ -13,8 +13,8 @@ run_test() {
     local output_file="$3"
 
     echo "Running test: $description"
-    echo "$command" > "$OUTPUT_DIR/$output_file"
-    eval "$command" >> "$OUTPUT_DIR/$output_file" 2>&1
+    echo "$command" >"$OUTPUT_DIR/$output_file"
+    eval "$command" >>"$OUTPUT_DIR/$output_file" 2>&1
 }
 
 # Basic functionality tests


### PR DESCRIPTION
This PR implements a shell script formatter using shfmt (mvdan/sh) as per issue #58. Changes include:

- Add shell script formatter with automatic download from GitHub releases
- Configure formatting to use 4-space indentation per project standards
- Create a combined `run-shell-checks` script that runs both formatter and linter
- Update GitHub Actions workflow to run formatter before linter
- Update run-all-checks to use the combined script

cc: #58