### PR TITLE
Add minimum test coverage threshold of 80%

### DIFF
--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -40,6 +40,25 @@ echo -e "\nGenerating coverage reports..."
 uv run coverage xml
 uv run coverage html
 
+# Set minimum coverage threshold (80%)
+MIN_COVERAGE=80
+
+# Check coverage percentage against minimum threshold
+echo -e "\n=== Coverage Threshold Check ==="
+# Get total coverage percentage (removing the % sign and any decimal places)
+COVERAGE_PCT=$(uv run coverage report | tail -n 1 | awk '{print $NF}' | sed 's/%//' | cut -d. -f1)
+
+echo "Current coverage: ${COVERAGE_PCT}%"
+echo "Minimum required: ${MIN_COVERAGE}%"
+
+if [ "${COVERAGE_PCT}" -lt "${MIN_COVERAGE}" ]; then
+    echo -e "\n❌ ERROR: Test coverage (${COVERAGE_PCT}%) is below the minimum threshold of ${MIN_COVERAGE}%"
+    echo "Please add more tests to improve coverage before committing."
+    exit 1
+else
+    echo -e "✅ Test coverage meets the minimum threshold."
+fi
+
 # Display a focused coverage summary in the terminal
 # Skip fully covered files and sort by coverage percentage (lowest first)
 echo -e "\n=== Coverage Summary ==="


### PR DESCRIPTION
This PR implements a minimum test coverage threshold of 80% for the project as requested in issue #12. 

The changes:
- Add coverage threshold check to the `scripts/run-tests` script
- Set minimum coverage requirement to 80%
- Fail the tests if coverage falls below this threshold
- Display current coverage percentage and threshold in the output

With this change, any PR that would cause test coverage to drop below 80% will fail in CI, ensuring we maintain good test coverage across the codebase.

cc: #12