### PR TITLE
Remove deprecated whitespace fixer tests

### DIFF
--- a/tests/test_fix_whitespace.py
+++ b/tests/test_fix_whitespace.py
@@ -1,3 +1,0 @@
-import pytest
-
-pytest.skip("Deprecated whitespace fixer tests; using Prettier now", allow_module_level=True)


### PR DESCRIPTION
This PR removes the deprecated whitespace fixer test file as described in issue #67.

The test file `tests/test_fix_whitespace.py` contained a module-level skip directive indicating that these tests are deprecated since the project now uses Prettier for formatting. Removing this file helps clean up the test suite and eliminates a skipped test that was showing up in test runs.

All checks have been run and pass successfully.

cc: #67