### PR TITLE
Ensure uvx works with this tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can run the tool directly from GitHub without installing it using `uvx`:
 
 ```bash
 # Run directly from GitHub with uvx (no installation needed)
-uvx -m plex_history_report github:claytono/plex-history-report --help
+uvx github:claytono/plex-history-report --help
 ```
 
 This will automatically download the repository and install all required dependencies. You'll still
@@ -60,7 +60,7 @@ need to configure your Plex server details - see the Configuration section below
 
    ```bash
    # Run with uvx without installing
-   uvx -m plex_history_report --help
+   uvx plex_history_report --help
 
    # Or use the provided wrapper script
    ./bin/plex-history-report --help
@@ -92,10 +92,10 @@ plex-history-report --tv
 ./bin/plex-history-report --tv
 
 # Using uvx from local repository
-uvx -m plex_history_report --tv
+uvx plex_history_report --tv
 
 # Using uvx directly from GitHub
-uvx -m plex_history_report github:claytono/plex-history-report --tv
+uvx github:claytono/plex-history-report --tv
 ```
 
 ### Output Formats

--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ hope you find it useful too.
 - **User Management**: Query available Plex users and filter statistics by specific users
 - **Recently Watched**: View recently watched media with detailed information
 
+## Quick Start with UVX
+
+You can run the tool directly from GitHub without installing it using `uvx`:
+
+```bash
+# Run directly from GitHub with uvx (no installation needed)
+uvx -m plex_history_report github:claytono/plex-history-report --help
+```
+
+This will automatically download the repository and install all required dependencies. You'll still
+need to configure your Plex server details - see the Configuration section below.
+
 ## Installation
 
 ### Prerequisites
@@ -44,6 +56,16 @@ hope you find it useful too.
    uv pip install -e .
    ```
 
+3. Alternatively, run directly from the cloned repository:
+
+   ```bash
+   # Run with uvx without installing
+   uvx -m plex_history_report --help
+
+   # Or use the provided wrapper script
+   ./bin/plex-history-report --help
+   ```
+
 ## Configuration
 
 Create a `config.yaml` file in the project directory with the following structure:
@@ -60,19 +82,20 @@ You can obtain your Plex token by following the instructions in the
 
 ## Usage
 
-The tool can be run directly using the included script:
+The tool can be run in several ways:
 
 ```bash
-# Basic usage for TV shows or movies
+# Using the installed command if you installed with uv pip install
+plex-history-report --tv
+
+# Using the wrapper script from cloned repository
 ./bin/plex-history-report --tv
-./bin/plex-history-report --movies
 
-# User-specific statistics
-./bin/plex-history-report --tv --user username
-./bin/plex-history-report --movies --user username
+# Using uvx from local repository
+uvx -m plex_history_report --tv
 
-# List available Plex users
-./bin/plex-history-report --list-users
+# Using uvx directly from GitHub
+uvx -m plex_history_report github:claytono/plex-history-report --tv
 ```
 
 ### Output Formats

--- a/plex_history_report/__main__.py
+++ b/plex_history_report/__main__.py
@@ -1,9 +1,10 @@
 """Main entry point for direct module execution.
 
-This file enables running the module directly with: python -m plex_history_report
-or with uvx: uvx -m plex_history_report
+This file enables running the module directly with various methods:
+- python -m plex_history_report
+- uvx git+https://github.com/claytono/plex-history-report
 
-It's particularly useful for running the tool directly from GitHub with uvx.
+It allows the tool to be run directly without installation.
 """
 
 from .cli import main

--- a/plex_history_report/__main__.py
+++ b/plex_history_report/__main__.py
@@ -1,0 +1,12 @@
+"""Main entry point for direct module execution.
+
+This file enables running the module directly with: python -m plex_history_report
+or with uvx: uvx -m plex_history_report
+
+It's particularly useful for running the tool directly from GitHub with uvx.
+"""
+
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/plex_history_report/cli.py
+++ b/plex_history_report/cli.py
@@ -12,7 +12,7 @@ from rich.console import Console
 from rich.logging import RichHandler
 
 from plex_history_report.config import (
-    DEFAULT_CONFIG_PATH,
+    CWD_CONFIG_PATH,
     ConfigError,
     create_default_config,
     load_config,
@@ -185,7 +185,8 @@ def run(args: argparse.Namespace) -> int:
 
     # Load or create configuration
     try:
-        config_path = Path(args.config) if args.config else DEFAULT_CONFIG_PATH
+        # Use specified config path or CWD for config creation/loading
+        config_path = Path(args.config) if args.config else CWD_CONFIG_PATH
 
         # Check if config file exists, create it if it doesn't
         if not config_path.exists() and not args.create_config:
@@ -198,7 +199,8 @@ def run(args: argparse.Namespace) -> int:
             )
             return 0
 
-        config = load_config(config_path)
+        # This will use the correct priority for loading if no path is specified
+        config = load_config(config_path if config_path.exists() else None)
     except ConfigError as e:
         console.print(f"[bold red]Configuration error:[/bold red] {e}")
         console.print("\nRun with --create-config to create a default configuration file.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dev = [
 plex-history-report = "plex_history_report.cli:main"
 
 [tool.setuptools]
-packages = ["plex_history_report"]
+packages = ["plex_history_report", "plex_history_report.formatters"]
 
 [tool.black]
 line-length = 100

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -83,7 +83,10 @@ class TestConfig(unittest.TestCase):
         }
         config_path = self.create_test_config(valid_config)
 
-        with patch("plex_history_report.config.DEFAULT_CONFIG_PATH", config_path):
+        # Need to mock both CWD_CONFIG_PATH and PKG_CONFIG_PATH to ensure our test works
+        with patch("plex_history_report.config.CWD_CONFIG_PATH", Path("/nonexistent/path")), patch(
+            "plex_history_report.config.PKG_CONFIG_PATH", config_path
+        ):
             # Load the configuration without specifying a path
             loaded_config = load_config()
 
@@ -239,7 +242,8 @@ class TestConfig(unittest.TestCase):
         # Mock DEFAULT_CONFIG_PATH to point to our temp file
         temp_default_config = self.temp_path / "default_config.yaml"
 
-        with patch("plex_history_report.config.DEFAULT_CONFIG_PATH", temp_default_config):
+        # Need to mock CWD_CONFIG_PATH to control where the config is created
+        with patch("plex_history_report.config.CWD_CONFIG_PATH", temp_default_config):
             # Create a default configuration without specifying a path
             result_path = create_default_config()
 


### PR DESCRIPTION
This PR fixes issue #23 by ensuring the tool works correctly with `uvx`.

Changes include:
1. Added a `__main__.py` file to enable direct module execution
2. Fixed configuration handling to prioritize files in the current working directory
3. Modified `pyproject.toml` to explicitly include subpackages
4. Fixed an issue where existing config files could be overwritten

With these changes, the tool can now be run directly from GitHub using:
```bash
uvx git+https://github.com/claytono/plex-history-report
```

And it will correctly find and use a `config.yaml` file in the current working directory.

cc: #23