### PR TITLE
Fix summary panel width in Rich formatter

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,9 +5,11 @@
 - This project is hosted on GitHub at `claytono/plex-history-report`.
 - Group multiple commands into logical sets and offer to run them in a single invocation or
   separately.
-- We are using Python 3 for this project. Use the `python3` binary when invoking Python directly.
 - We are using `uv` for Python package management. Follow best practices for `uv` in all aspects of
   this project.
+- The plex-history-stats cool can be run by invoking `bin/plex-history-report`.
+- The `scripts/` directory contains various helper scripts for running tests, linters, and other
+  development tasks.
 
 ## General Guidelines
 

--- a/plex_history_report/formatters/__init__.py
+++ b/plex_history_report/formatters/__init__.py
@@ -10,7 +10,7 @@ from plex_history_report.formatters.csv_formatter import CsvFormatter
 from plex_history_report.formatters.factory import FormatterFactory
 from plex_history_report.formatters.json_formatter import JsonFormatter
 from plex_history_report.formatters.markdown_formatter import MarkdownFormatter
-from plex_history_report.formatters.rich import RichFormatter
+from plex_history_report.formatters.rich_formatter import RichFormatter
 from plex_history_report.formatters.yaml_formatter import YamlFormatter
 
 __all__ = [

--- a/plex_history_report/formatters/base.py
+++ b/plex_history_report/formatters/base.py
@@ -1,6 +1,7 @@
 """Base formatter for displaying Plex History Report statistics."""
 
 import logging
+from abc import ABC, abstractmethod
 from typing import Dict, List, Optional
 
 from rich.console import Console
@@ -8,9 +9,10 @@ from rich.console import Console
 logger = logging.getLogger(__name__)
 
 
-class BaseFormatter:
+class BaseFormatter(ABC):
     """Base class for formatters."""
 
+    @abstractmethod
     def format_show_statistics(self, stats: List[Dict]) -> str:
         """Format show statistics.
 
@@ -20,8 +22,9 @@ class BaseFormatter:
         Returns:
             Formatted string representation of the statistics.
         """
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def format_movie_statistics(self, stats: List[Dict]) -> str:
         """Format movie statistics.
 
@@ -31,8 +34,9 @@ class BaseFormatter:
         Returns:
             Formatted string representation of the statistics.
         """
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def format_recently_watched(self, stats: List[Dict], media_type: str = "show") -> str:
         """Format recently watched media.
 
@@ -43,7 +47,7 @@ class BaseFormatter:
         Returns:
             Formatted string representation of the recently watched media.
         """
-        raise NotImplementedError()
+        pass
 
     def format_content(
         self,
@@ -67,7 +71,7 @@ class BaseFormatter:
         """
         outputs = []
 
-        # Format main statistics
+        # Format main statistics (each formatter now includes summary data in these methods)
         if media_type == "show":
             outputs.append(self.format_show_statistics(stats))
         else:

--- a/plex_history_report/formatters/factory.py
+++ b/plex_history_report/formatters/factory.py
@@ -7,7 +7,7 @@ from plex_history_report.formatters.compact_formatter import CompactFormatter
 from plex_history_report.formatters.csv_formatter import CsvFormatter
 from plex_history_report.formatters.json_formatter import JsonFormatter
 from plex_history_report.formatters.markdown_formatter import MarkdownFormatter
-from plex_history_report.formatters.rich import RichFormatter
+from plex_history_report.formatters.rich_formatter import RichFormatter
 from plex_history_report.formatters.yaml_formatter import YamlFormatter
 
 

--- a/plex_history_report/formatters/rich_formatter.py
+++ b/plex_history_report/formatters/rich_formatter.py
@@ -69,6 +69,40 @@ class RichFormatter(BaseFormatter):
             )
 
         console.print(table)
+
+        # Add summary section directly in this method (moved from format_summary)
+        if stats:
+            # Calculate show summary statistics
+            total_shows = len(stats)
+            watched_shows = sum(1 for show in stats if show["watched_episodes"] > 0)
+            total_episodes = sum(show["total_episodes"] for show in stats)
+            watched_episodes = sum(show["watched_episodes"] for show in stats)
+            total_watch_time = sum(show["total_watch_time_minutes"] for show in stats)
+
+            # Format watch time
+            hours = int(total_watch_time // 60)
+            minutes = int(total_watch_time % 60)
+
+            # Calculate overall completion percentage, rounded to 1 decimal place
+            completion_percentage = (
+                (watched_episodes / total_episodes * 100) if total_episodes > 0 else 0
+            )
+
+            # Create a summary panel with width matching the table
+            summary = Panel(
+                f"Total Shows: {total_shows}\n"
+                f"Watched Shows: {watched_shows}\n"
+                f"Total Episodes: {total_episodes}\n"
+                f"Watched Episodes: {watched_episodes}\n"
+                f"Overall Completion: {completion_percentage:.1f}%\n"
+                f"Total Watch Time: {hours} hours, {minutes} minutes",
+                title="TV Show Summary",
+                border_style="green",
+                width=table.width or 80,  # Use table width or fallback to 80 if not available
+            )
+
+            console.print(summary)
+
         return string_io.getvalue()
 
     def format_movie_statistics(self, stats: List[Dict]) -> str:
@@ -126,6 +160,44 @@ class RichFormatter(BaseFormatter):
             )
 
         console.print(table)
+
+        # Add summary section directly in this method (moved from format_summary)
+        if stats:
+            # Calculate movie summary statistics
+            total_movies = len(stats)
+            watched_movies = sum(1 for movie in stats if movie["watched"])
+            watch_count = sum(movie["watch_count"] for movie in stats)
+            total_duration = sum(movie["duration_minutes"] for movie in stats)
+            watched_duration = sum(
+                movie["duration_minutes"] * movie["watch_count"]
+                for movie in stats
+                if movie["watched"]
+            )
+
+            # Format durations
+            total_hours = int(total_duration // 60)
+            total_minutes = int(total_duration % 60)
+            watched_hours = int(watched_duration // 60)
+            watched_minutes = int(watched_duration % 60)
+
+            # Calculate completion percentage, rounded to 1 decimal place
+            completion_percentage = (watched_movies / total_movies * 100) if total_movies > 0 else 0
+
+            # Create a summary panel with width matching the table
+            summary = Panel(
+                f"Total Movies: {total_movies}\n"
+                f"Watched Movies: {watched_movies}\n"
+                f"Completion: {completion_percentage:.1f}%\n"
+                f"Total Watch Count: {watch_count}\n"
+                f"Total Duration: {total_hours} hours, {total_minutes} minutes\n"
+                f"Total Watch Time: {watched_hours} hours, {watched_minutes} minutes",
+                title="Movie Summary",
+                border_style="green",
+                width=table.width or 80,  # Use table width or fallback to 80 if not available
+            )
+
+            console.print(summary)
+
         return string_io.getvalue()
 
     def format_recently_watched(self, stats: List[Dict], media_type: str = "show") -> str:
@@ -206,85 +278,4 @@ class RichFormatter(BaseFormatter):
                 table.add_row(movie["title"], formatted_date, str(movie["watch_count"]), duration)
 
         console.print(table)
-        return string_io.getvalue()
-
-    def format_summary(self, stats: List[Dict], media_type: str = "show") -> str:
-        """Format summary statistics.
-
-        Args:
-            stats: List of statistics.
-            media_type: Type of media ("show" or "movie").
-
-        Returns:
-            Formatted string representation of the summary.
-        """
-        # Create a StringIO-based console to capture output
-        string_io = io.StringIO()
-        console = Console(file=string_io, width=120)
-
-        if not stats:
-            return ""
-
-        if media_type == "show":
-            # Calculate show summary statistics
-            total_shows = len(stats)
-            watched_shows = sum(1 for show in stats if show["watched_episodes"] > 0)
-            total_episodes = sum(show["total_episodes"] for show in stats)
-            watched_episodes = sum(show["watched_episodes"] for show in stats)
-            total_watch_time = sum(show["total_watch_time_minutes"] for show in stats)
-
-            # Format watch time
-            hours = int(total_watch_time // 60)
-            minutes = int(total_watch_time % 60)
-
-            # Calculate overall completion percentage, rounded to 1 decimal place
-            completion_percentage = (
-                (watched_episodes / total_episodes * 100) if total_episodes > 0 else 0
-            )
-
-            # Create a summary panel
-            summary = Panel(
-                f"Total Shows: {total_shows}\n"
-                f"Watched Shows: {watched_shows}\n"
-                f"Total Episodes: {total_episodes}\n"
-                f"Watched Episodes: {watched_episodes}\n"
-                f"Overall Completion: {completion_percentage:.1f}%\n"
-                f"Total Watch Time: {hours} hours, {minutes} minutes",
-                title="TV Show Summary",
-                border_style="green",
-            )
-        else:  # movies
-            # Calculate movie summary statistics
-            total_movies = len(stats)
-            watched_movies = sum(1 for movie in stats if movie["watched"])
-            watch_count = sum(movie["watch_count"] for movie in stats)
-            total_duration = sum(movie["duration_minutes"] for movie in stats)
-            watched_duration = sum(
-                movie["duration_minutes"] * movie["watch_count"]
-                for movie in stats
-                if movie["watched"]
-            )
-
-            # Format durations
-            total_hours = int(total_duration // 60)
-            total_minutes = int(total_duration % 60)
-            watched_hours = int(watched_duration // 60)
-            watched_minutes = int(watched_duration % 60)
-
-            # Calculate completion percentage, rounded to 1 decimal place
-            completion_percentage = (watched_movies / total_movies * 100) if total_movies > 0 else 0
-
-            # Create a summary panel
-            summary = Panel(
-                f"Total Movies: {total_movies}\n"
-                f"Watched Movies: {watched_movies}\n"
-                f"Completion: {completion_percentage:.1f}%\n"
-                f"Total Watch Count: {watch_count}\n"
-                f"Total Duration: {total_hours} hours, {total_minutes} minutes\n"
-                f"Total Watch Time: {watched_hours} hours, {watched_minutes} minutes",
-                title="Movie Summary",
-                border_style="green",
-            )
-
-        console.print(summary)
         return string_io.getvalue()

--- a/plex_history_report/formatters/rich_formatter.py
+++ b/plex_history_report/formatters/rich_formatter.py
@@ -68,6 +68,17 @@ class RichFormatter(BaseFormatter):
                 watch_time,
             )
 
+        # Create a temporary string to capture just the table for width measurement
+        temp_io = io.StringIO()
+        temp_console = Console(file=temp_io, width=120)
+        temp_console.print(table)
+        table_output = temp_io.getvalue()
+
+        # Find the width of the table by finding the longest line in the rendered table
+        table_lines = table_output.split("\n")
+        table_width = max(len(line) for line in table_lines if line.strip())
+
+        # Now print the actual table
         console.print(table)
 
         # Add summary section directly in this method (moved from format_summary)
@@ -98,7 +109,7 @@ class RichFormatter(BaseFormatter):
                 f"Total Watch Time: {hours} hours, {minutes} minutes",
                 title="TV Show Summary",
                 border_style="green",
-                width=table.width or 80,  # Use table width or fallback to 80 if not available
+                width=table_width,  # Use the exact measured table width
             )
 
             console.print(summary)
@@ -159,6 +170,17 @@ class RichFormatter(BaseFormatter):
                 movie["title"], str(movie["watch_count"]), formatted_date, duration, rating
             )
 
+        # Create a temporary string to capture just the table for width measurement
+        temp_io = io.StringIO()
+        temp_console = Console(file=temp_io, width=120)
+        temp_console.print(table)
+        table_output = temp_io.getvalue()
+
+        # Find the width of the table by finding the longest line in the rendered table
+        table_lines = table_output.split("\n")
+        table_width = max(len(line) for line in table_lines if line.strip())
+
+        # Now print the actual table
         console.print(table)
 
         # Add summary section directly in this method (moved from format_summary)
@@ -193,7 +215,7 @@ class RichFormatter(BaseFormatter):
                 f"Total Watch Time: {watched_hours} hours, {watched_minutes} minutes",
                 title="Movie Summary",
                 border_style="green",
-                width=table.width or 80,  # Use table width or fallback to 80 if not available
+                width=table_width,  # Use the exact measured table width
             )
 
             console.print(summary)

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -582,8 +582,8 @@ class TestIntegratedFormatting(unittest.TestCase):
         """Test that RichFormatter's methods are called correctly."""
         formatter = FormatterFactory.get_formatter("table")
 
-        # Set up mocks to return string values (as now expected)
-        mock_format_show.return_value = "Mock show statistics"
+        # Set up mocks to return string values
+        mock_format_show.return_value = "Mock show statistics with summary"
         mock_format_recent.return_value = "Mock recently watched"
 
         # Call format_content
@@ -597,7 +597,7 @@ class TestIntegratedFormatting(unittest.TestCase):
 
         # Check that the returned strings are included in the output
         self.assertEqual(len(outputs), 2)
-        self.assertEqual(outputs[0], "Mock show statistics")
+        self.assertEqual(outputs[0], "Mock show statistics with summary")
         self.assertEqual(outputs[1], "Mock recently watched")
 
 

--- a/tests/test_rich_formatter.py
+++ b/tests/test_rich_formatter.py
@@ -140,6 +140,21 @@ class TestRichFormatter(unittest.TestCase):
         self.assertIn("0m", result)  # 0 minutes for Test Show 2
         self.assertIn("30m", result)  # 30 minutes for Test Show 3
 
+    def test_format_show_statistics_contains_summary(self):
+        """Test that show statistics output includes summary information."""
+        result = self.formatter.format_show_statistics(self.show_data)
+
+        # Check that output contains the summary title
+        self.assertIn("TV Show Summary", result)
+
+        # Check that summary statistics are correct
+        self.assertIn("Total Shows: 3", result)
+        self.assertIn("Watched Shows: 2", result)  # Test Show 2 has 0 watched episodes
+        self.assertIn("Total Episodes: 35", result)  # 10 + 20 + 5 = 35
+        self.assertIn("Watched Episodes: 10", result)  # 5 + 0 + 5 = 10
+        self.assertIn("Overall Completion: 28.6%", result)  # 10/35 = 28.6%
+        self.assertIn("Total Watch Time: 3 hours, 0 minutes", result)  # 150 + 0 + 30 = 180 minutes
+
     def test_format_movie_statistics_empty(self):
         """Test formatting empty movie statistics."""
         result = self.formatter.format_movie_statistics([])
@@ -175,6 +190,26 @@ class TestRichFormatter(unittest.TestCase):
         self.assertIn("8.5", result)  # Test Movie 1 rating
         self.assertIn("-", result)  # No rating for Test Movie 2
         self.assertIn("9.2", result)  # Test Movie 3 rating
+
+    def test_format_movie_statistics_contains_summary(self):
+        """Test that movie statistics output includes summary information."""
+        result = self.formatter.format_movie_statistics(self.movie_data)
+
+        # Check that output contains the summary title
+        self.assertIn("Movie Summary", result)
+
+        # Check that summary statistics are correct
+        self.assertIn("Total Movies: 3", result)
+        self.assertIn("Watched Movies: 2", result)  # Test Movie 2 has watched=False
+        self.assertIn("Completion: 66.7%", result)  # 2/3 = 66.7%
+        self.assertIn("Total Watch Count: 5", result)  # 2 + 0 + 3 = 5
+        self.assertIn("Total Duration: 4 hours, 15 minutes", result)  # 120 + 90 + 45 = 255 minutes
+
+        # Check watched duration calculation (watched movies only)
+        # Test Movie 1: 120 minutes x 2 watches = 240 minutes
+        # Test Movie 3: 45 minutes x 3 watches = 135 minutes
+        # Total: 375 minutes = 6 hours 15 minutes
+        self.assertIn("Total Watch Time: 6 hours, 15 minutes", result)
 
     def test_format_recently_watched_shows_empty(self):
         """Test formatting empty recently watched shows."""
@@ -237,46 +272,6 @@ class TestRichFormatter(unittest.TestCase):
         # Check duration formatting
         self.assertIn("1h 50m", result)  # 110 minutes for Recent Movie 1
         self.assertIn("1h 35m", result)  # 95 minutes for Recent Movie 2
-
-    def test_format_show_summary(self):
-        """Test formatting show summary."""
-        result = self.formatter.format_summary(self.show_data, media_type="show")
-
-        # Check that output contains the summary title
-        self.assertIn("TV Show Summary", result)
-
-        # Check that summary statistics are correct
-        self.assertIn("Total Shows: 3", result)
-        self.assertIn("Watched Shows: 2", result)  # Test Show 2 has 0 watched episodes
-        self.assertIn("Total Episodes: 35", result)  # 10 + 20 + 5 = 35
-        self.assertIn("Watched Episodes: 10", result)  # 5 + 0 + 5 = 10
-        self.assertIn("Overall Completion: 28.6%", result)  # 10/35 = 28.6%
-        self.assertIn("Total Watch Time: 3 hours, 0 minutes", result)  # 150 + 0 + 30 = 180 minutes
-
-    def test_format_movie_summary(self):
-        """Test formatting movie summary."""
-        result = self.formatter.format_summary(self.movie_data, media_type="movie")
-
-        # Check that output contains the summary title
-        self.assertIn("Movie Summary", result)
-
-        # Check that summary statistics are correct
-        self.assertIn("Total Movies: 3", result)
-        self.assertIn("Watched Movies: 2", result)  # Test Movie 2 has watched=False
-        self.assertIn("Completion: 66.7%", result)  # 2/3 = 66.7%
-        self.assertIn("Total Watch Count: 5", result)  # 2 + 0 + 3 = 5
-        self.assertIn("Total Duration: 4 hours, 15 minutes", result)  # 120 + 90 + 45 = 255 minutes
-
-        # Check watched duration calculation (watched movies only)
-        # Test Movie 1: 120 minutes x 2 watches = 240 minutes
-        # Test Movie 3: 45 minutes x 3 watches = 135 minutes
-        # Total: 375 minutes = 6 hours 15 minutes
-        self.assertIn("Total Watch Time: 6 hours, 15 minutes", result)
-
-    def test_format_summary_empty(self):
-        """Test formatting empty summary."""
-        result = self.formatter.format_summary([], media_type="show")
-        self.assertEqual(result, "")
 
     def test_rich_console_output(self):
         """Test that rich console output works properly."""


### PR DESCRIPTION
This PR addresses issue #27 by:

1. Renaming `rich.py` to `rich_formatter.py` for consistency with other formatters
2. Moving summary logic from `BaseFormatter` into each formatter's statistics methods
3. Ensuring summary data appears in the default output format
4. Fixing the summary panel width to exactly match the table width using a precise measurement technique

The summary panels now have the proper width that matches their respective tables, creating a much more visually consistent output.

cc: #27