### PR TITLE
Remove movie ratings column

### DIFF
--- a/plex_history_report/formatters/rich_formatter.py
+++ b/plex_history_report/formatters/rich_formatter.py
@@ -145,7 +145,6 @@ class RichFormatter(BaseFormatter):
         table.add_column("Watch Count", justify="right", style="green", width=12)
         table.add_column("Last Watched", justify="right", style="blue", width=16)
         table.add_column("Duration", justify="right", style="magenta", width=10)
-        table.add_column("Rating", justify="right", style="yellow", width=8)
 
         # Add rows for each movie
         for movie in stats:
@@ -163,12 +162,7 @@ class RichFormatter(BaseFormatter):
             minutes = int(movie["duration_minutes"] % 60)
             duration = f"{hours}h {minutes}m" if hours > 0 else f"{minutes}m"
 
-            # Format rating
-            rating = f"{movie['rating']}" if movie["rating"] else "-"
-
-            table.add_row(
-                movie["title"], str(movie["watch_count"]), formatted_date, duration, rating
-            )
+            table.add_row(movie["title"], str(movie["watch_count"]), formatted_date, duration)
 
         # Create a temporary string to capture just the table for width measurement
         temp_io = io.StringIO()

--- a/tests/test_rich_formatter.py
+++ b/tests/test_rich_formatter.py
@@ -186,11 +186,6 @@ class TestRichFormatter(unittest.TestCase):
         self.assertIn("1h 30m", result)  # 90 minutes for Test Movie 2
         self.assertIn("45m", result)  # 45 minutes for Test Movie 3
 
-        # Check rating formatting
-        self.assertIn("8.5", result)  # Test Movie 1 rating
-        self.assertIn("-", result)  # No rating for Test Movie 2
-        self.assertIn("9.2", result)  # Test Movie 3 rating
-
     def test_format_movie_statistics_contains_summary(self):
         """Test that movie statistics output includes summary information."""
         result = self.formatter.format_movie_statistics(self.movie_data)


### PR DESCRIPTION
This PR removes the movie ratings column from the Rich formatter's movie statistics table as it's not relevant per issue #63.

Changes made:
- Removed the "Rating" column from the movie statistics table in RichFormatter
- Removed the code that formats the rating for each movie
- Updated the corresponding test to no longer check for rating information

cc: #63