### PR TITLE
Add McCabe complexity checking via Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,10 +55,21 @@ select = [
     "ARG", # flake8-unused-arguments
     "PTH", # use pathlib
     "RUF", # ruff-specific rules
+    "C90", # McCabe complexity
 ]
 ignore = [
     "E501", # line too long (handled by formatter)
 ]
+
+[tool.ruff.lint.mccabe]
+# Max complexity allowed, default is 10 which is typically a good threshold
+max-complexity = 10
+
+# Temporarily ignore C901 (complexity) errors for specific functions while we work on refactoring
+[tool.ruff.lint.per-file-ignores]
+"plex_history_report/cli.py" = ["C901"]          # Will be refactored in follow-up PRs
+"plex_history_report/config.py" = ["C901"]       # Will be refactored in follow-up PRs
+"plex_history_report/plex_client.py" = ["C901"]  # Will be refactored in follow-up PRs
 
 [tool.ruff.format]
 quote-style = "double"


### PR DESCRIPTION
This PR implements the first part of our code complexity measurement plan from issue #20. It:

1. Adds the C90 rule set (McCabe complexity) to Ruff's configuration
2. Sets a standard complexity threshold of 10
3. Adds temporary exemptions for existing complex functions

Running the linter has identified 8 functions that exceed our complexity threshold:
- `run` in `cli.py` with complexity 28 (main target for refactoring)
- `load_config` in `config.py` with complexity 11
- Several methods in `plex_client.py` with complexities ranging from 13 to 22

These functions will be refactored in follow-up PRs, starting with the `run` method in `cli.py`.

cc: #20